### PR TITLE
chore: update chart (community gallery image rules)

### DIFF
--- a/chart/validator-plugin-azure/crds/validation.spectrocloud.labs_azurevalidators.yaml
+++ b/chart/validator-plugin-azure/crds/validation.spectrocloud.labs_azurevalidators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: azurevalidators.validation.spectrocloud.labs
 spec:
   group: validation.spectrocloud.labs
@@ -20,14 +20,19 @@ spec:
         description: AzureValidator is the Schema for the azurevalidators API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -35,56 +40,106 @@ spec:
             description: AzureValidatorSpec defines the desired state of AzureValidator
             properties:
               auth:
+                description: AzureAuth defines authentication configuration for an
+                  AzureValidator.
                 properties:
                   implicit:
-                    description: If true, the AzureValidator will use the Azure SDK's
-                      default credential chain to authenticate. Set to true if using
-                      WorkloadIdentityCredentials.
+                    description: |-
+                      If true, the AzureValidator will use the Azure SDK's default credential chain to authenticate.
+                      Set to true if using WorkloadIdentityCredentials.
                     type: boolean
                   secretName:
-                    description: Name of a Secret in the same namespace as the AzureValidator
-                      that contains Azure credentials. The secret data's keys and
-                      values are expected to align with valid Azure environment variable
-                      credentials, per the options defined in https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#readme-environment-variables.
+                    description: |-
+                      Name of a Secret in the same namespace as the AzureValidator that contains Azure credentials.
+                      The secret data's keys and values are expected to align with valid Azure environment variable credentials,
+                      per the options defined in https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#readme-environment-variables.
                     type: string
                 required:
                 - implicit
                 type: object
-              rbacRules:
-                description: Rules for validating that the correct role assignments
-                  have been created in Azure RBAC to provide needed permissions.
+              communityGalleryImageRules:
+                description: |-
+                  Rules for validating that images exist in an Azure Compute Gallery published as a community
+                  gallery.
                 items:
-                  description: Conveys that a specified security principal (aka principal)
-                    should have the specified permissions, via roles. It doesn't matter
-                    which roles provide the permissions as long as enough role assignments
-                    exist that the principal has all of the permissions and no deny
-                    assignments exist that deny the permissions.
+                  description: |-
+                    CommunityGalleryImageRule verifies that one or more images in a community gallery exist and are
+                    accessible by a particular subscription.
+                  properties:
+                    gallery:
+                      description: Gallery is the community gallery.
+                      properties:
+                        location:
+                          description: Location is the location of the community gallery
+                            (e.g. "westus").
+                          maxLength: 50
+                          type: string
+                        name:
+                          description: Name is the name of the community gallery.
+                          maxLength: 200
+                          type: string
+                      required:
+                      - location
+                      - name
+                      type: object
+                    images:
+                      description: Images is a list of image names.
+                      items:
+                        type: string
+                      maxItems: 1000
+                      minItems: 1
+                      type: array
+                    name:
+                      description: |-
+                        Name is a unique identifier for the rule in the validator. Used to ensure conditions do not
+                        overwrite each other.
+                      maxLength: 200
+                      type: string
+                    subscriptionID:
+                      description: SubscriptionID is the ID of the subscription.
+                      type: string
+                  required:
+                  - gallery
+                  - images
+                  - name
+                  - subscriptionID
+                  type: object
+                type: array
+              rbacRules:
+                description: |-
+                  Rules for validating that the correct role assignments have been created in Azure RBAC to
+                  provide needed permissions.
+                items:
+                  description: |-
+                    RBACRule verifies that a security principal has permissions via role assignments and that no deny
+                    assignments deny the permissions.
                   properties:
                     name:
-                      description: Unique identifier for the rule in the validator.
-                        Used to ensure conditions do not overwrite each other.
+                      description: |-
+                        Unique identifier for the rule in the validator. Used to ensure conditions do not overwrite
+                        each other.
                       type: string
                     permissionSets:
-                      description: The permissions that the principal must have. If
-                        the principal has permissions less than this, validation will
-                        fail. If the principal has permissions equal to or more than
-                        this (e.g., inherited permissions from higher level scope,
-                        more roles than needed) validation will pass.
+                      description: |-
+                        The permissions that the principal must have. If the principal has permissions less than
+                        this, validation will fail. If the principal has permissions equal to or more than this
+                        (e.g., inherited permissions from higher level scope, more roles than needed) validation
+                        will pass.
                       items:
-                        description: Conveys that the security principal should be
-                          the member of a role assignment that provides the specified
-                          role for the specified scope. Scope can be either subscription,
+                        description: |-
+                          PermissionSet is part of an RBAC rule and verifies that a security principal has the specified
+                          permissions (via role assignments) at the specified scope. Scope can be either subscription,
                           resource group, or resource.
                         properties:
                           actions:
-                            description: If provided, the actions that the role must
-                              be able to perform. Must not contain any wildcards.
-                              If not specified, the role is assumed to already be
-                              able to perform all required actions.
+                            description: |-
+                              Actions is a list of actions that the role must be able to perform. Must not contain any
+                              wildcards. If not specified, the role is assumed to already be able to perform all required
+                              actions.
                             items:
-                              description: ActionStr is a type used for Action strings
-                                and DataAction strings. Alias exists to enable kubebuilder
-                                max string length validation for arrays of these.
+                              description: |-
+                                ActionStr is a type used for Action strings and DataAction strings. Alias exists to enable
+                                kubebuilder max string length validation for arrays of these.
                               maxLength: 200
                               type: string
                             maxItems: 1000
@@ -93,14 +148,14 @@ spec:
                             - message: Actions cannot have wildcards.
                               rule: self.all(item, !item.contains('*'))
                           dataActions:
-                            description: If provided, the data actions that the role
-                              must be able to perform. Must not contain any wildcards.
-                              If not provided, the role is assumed to already be able
-                              to perform all required data actions.
+                            description: |-
+                              DataActions is a list of data actions that the role must be able to perform. Must not
+                              contain any wildcards. If not provided, the role is assumed to already be able to perform
+                              all required data actions.
                             items:
-                              description: ActionStr is a type used for Action strings
-                                and DataAction strings. Alias exists to enable kubebuilder
-                                max string length validation for arrays of these.
+                              description: |-
+                                ActionStr is a type used for Action strings and DataAction strings. Alias exists to enable
+                                kubebuilder max string length validation for arrays of these.
                               maxLength: 200
                               type: string
                             maxItems: 1000
@@ -109,11 +164,10 @@ spec:
                             - message: DataActions cannot have wildcards.
                               rule: self.all(item, !item.contains('*'))
                           scope:
-                            description: The minimum scope of the role. Role assignments
-                              found at higher level scopes will satisfy this. For
-                              example, a role assignment found with subscription scope
-                              will satisfy a permission set where the role scope specified
-                              is a resource group within that subscription.
+                            description: |-
+                              Scope is the minimum scope of the role. Role assignments found at higher level scopes will
+                              satisfy this. For example, a role assignment found with subscription scope will satisfy a
+                              permission set where the role scope specified is a resource group within that subscription.
                             type: string
                         required:
                         - scope
@@ -127,9 +181,9 @@ spec:
                         rule: self.all(item, size(item.actions) > 0 || size(item.dataActions)
                           > 0)
                     principalId:
-                      description: The principal being validated. This can be any
-                        type of principal - Device, ForeignGroup, Group, ServicePrincipal,
-                        or User.
+                      description: |-
+                        The principal being validated. This can be any type of principal - Device, ForeignGroup,
+                        Group, ServicePrincipal, or User.
                       type: string
                   required:
                   - name
@@ -143,7 +197,6 @@ spec:
                   rule: self.all(e, size(self.filter(x, x.name == e.name)) == 1)
             required:
             - auth
-            - rbacRules
             type: object
           status:
             description: AzureValidatorStatus defines the observed state of AzureValidator


### PR DESCRIPTION
We forgot to update the Helm chart in the recent PR that added the community gallery image rule. This takes care of that.