### PR TITLE
fix: Add reviewable-ext target to Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,11 @@ CHART_NAME=validator-plugin-azure
 .PHONY: dev
 dev:
 	devspace dev -n validator-plugin-azure-system
+
+# Static Analysis / CI
+
+chartCrds = chart/validator-plugin-azure/crds/validation.spectrocloud.labs_azurevalidators.yaml
+
+reviewable-ext:
+	rm $(chartCrds)
+	cp config/crd/bases/validation.spectrocloud.labs_azurevalidators.yaml $(chartCrds)


### PR DESCRIPTION
Target is used to ensure chart CRDs match what is generated by `make manifests`.