### PR TITLE
feat: add support for connecting to Azure Government and Azure in China

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Create a custom role with the permission `Microsoft.Compute/locations/communityG
 
 If you prefer to use a built-in role, the [Virtual Machine Contributor role](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/compute#virtual-machine-contributor) includes the necessary permissions to read community gallery images. However, be aware that this role also grants permissions to modify and delete virtual machines and other compute resources. If you only need read-only access, consider creating a custom role as described above.
 
+## Connecting to Azure Government or Azure in China
+
+By default, the plugin connects the Azure SDK to the public Azure cloud. Override `azureEnvironment` to change which cloud is connected to, using the following values.
+
+|`azureEnvironment` value|Cloud|
+|------------------------|-----|
+|AzureCloud|public Azure cloud|
+|AzureUSGovernment|[Azure Government](https://learn.microsoft.com/en-us/azure/azure-government/documentation-government-welcome)|
+|AzureChinaCloud|[Azure in China](https://learn.microsoft.com/en-us/azure/china/overview-operations)|
+
 ## Installation
 
 The Azure validator plugin is meant to be [installed by validator](https://github.com/validator-labs/validator/tree/gh_pages#installation) (via a ValidatorConfig), but it can also be installed directly as follows:

--- a/chart/validator-plugin-azure/README.md
+++ b/chart/validator-plugin-azure/README.md
@@ -38,6 +38,7 @@ The following table lists the configurable parameters of the Validator-plugin-az
 | `metricsService.ports` |  | `[{"name": "https", "port": 8443, "protocol": "TCP", "targetPort": "https"}]` |
 | `metricsService.type` |  | `"ClusterIP"` |
 | `auth.serviceAccountName` |  | `""` |
+| `azureEnvironment` |  | `"AzureCloud"` |
 
 
 

--- a/chart/validator-plugin-azure/templates/deployment.yaml
+++ b/chart/validator-plugin-azure/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
+          name: AZURE_ENVIRONMENT
+          value: {{ quote .Values.azureEnvironment }}
         volumeMounts: {{- toYaml .Values.controllerManager.manager.volumeMounts | nindent 10 }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
         livenessProbe:

--- a/chart/validator-plugin-azure/values.yaml
+++ b/chart/validator-plugin-azure/values.yaml
@@ -62,3 +62,6 @@ auth:
   # Override the service account used by Azure validator (optional, could be used for WorkloadIdentityCredentials on AKS)
   # WARNING: the chosen service account must include all RBAC privileges found in templates/manager-rbac.yaml
   serviceAccountName: ""
+# Optionally specify the Azure environment to use. Defaults to "AzureCloud" for public Azure cloud.
+# Other acceptable values are "AzureUSGovernment" and "AzureChinaCloud".
+azureEnvironment: "AzureCloud"

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -64,3 +64,7 @@ dev:
         - '!/go.sum'
         - '!/main.go'
         - 'Makefile'
+    # Uncomment to test the plugin connecting to Azure Government instead of Azure public cloud.
+    # env:
+    # - name: AZURE_ENVIRONMENT
+    #   value: AzureUSGovernment


### PR DESCRIPTION
## Issue
Resolves https://github.com/validator-labs/validator-plugin-azure/issues/239

## Description
Supports both so that any user of the open source Validator framework can connect to what they need to.

It can be enabled via the Helm chart (with value `azureEnvironment`), which passes the env var into the controller pod. An empty string is okay (the pod then defaults to public cloud), but for clarity, instead of omitting this from `values.yaml`, it's present with a default value that users can override to connect to other clouds.

Manually tested by first testing the plugin with a valid subscription ID for the public cloud (saw it working) and then added the env var to connect to Azure Government instead (and saw the expected error message, that the subscription couldn't be found).