### PR TITLE
fix: embedding structs related to `validationrule.Interface`

### DIFF
--- a/api/v1alpha1/azurevalidator_types.go
+++ b/api/v1alpha1/azurevalidator_types.go
@@ -52,7 +52,7 @@ func (s AzureValidatorSpec) ResultCount() int {
 // RBACRule verifies that a security principal has permissions via role assignments and that no deny
 // assignments deny the permissions.
 type RBACRule struct {
-	validationrule.ManuallyNamed `json:"-"`
+	validationrule.ManuallyNamed `json:",inline"`
 
 	// Unique identifier for the rule in the validator. Used to ensure conditions do not overwrite
 	// each other.
@@ -89,7 +89,7 @@ func (r *RBACRule) SetName(name string) {
 // CommunityGalleryImageRule verifies that one or more images in a community gallery exist and are
 // accessible by a particular subscription.
 type CommunityGalleryImageRule struct {
-	validationrule.ManuallyNamed `json:"-"`
+	validationrule.ManuallyNamed `json:",inline"`
 
 	// RuleName is a unique identifier for the rule in the validator. Used to ensure conditions do
 	// not overwrite each other.


### PR DESCRIPTION
## Description
Noticed when trying to integrate latest plugin releases with validatorctl that tests started failing because the CRD couldn't be applied. It complained about unknown fields. This is because the json tag used when embedding the struct lacked "inline". This fixes that.