### PR TITLE
fix: YAML rendering of structs embedded in rules

### DIFF
--- a/api/v1alpha1/azurevalidator_types.go
+++ b/api/v1alpha1/azurevalidator_types.go
@@ -55,7 +55,7 @@ func (s AzureValidatorSpec) ResultCount() int {
 // RBACRule verifies that a security principal has permissions via role assignments and that no deny
 // assignments deny the permissions.
 type RBACRule struct {
-	validationrule.ManuallyNamed `json:",inline"`
+	validationrule.ManuallyNamed `json:",inline" yaml:",omitempty"`
 
 	// Unique identifier for the rule in the validator. Used to ensure conditions do not overwrite
 	// each other.
@@ -92,7 +92,7 @@ func (r *RBACRule) SetName(name string) {
 // CommunityGalleryImageRule verifies that one or more images in a community gallery exist and are
 // accessible by a particular subscription.
 type CommunityGalleryImageRule struct {
-	validationrule.ManuallyNamed `json:",inline"`
+	validationrule.ManuallyNamed `json:",inline" yaml:",omitempty"`
 
 	// RuleName is a unique identifier for the rule in the validator. Used to ensure conditions do
 	// not overwrite each other.


### PR DESCRIPTION
## Description
In previous PRs, we made the plugin rules implement the new `validationrule.Interface` interface. We did not include YAML tags in rules to specify that the new field (`validationrule.ManuallyNamed` or `validationrule.AutomaticallyNamed` depending on the rule) should not be included when the rules are rendered to YAML. The validatorctl CLI renders the rules to YAML as part of what it does, so this caused errors when validatorctl tried to apply validator CRDs it generated to its cluster.