### PR TITLE
deps(deps): update module github.com/validator-labs/validator to v0.1.12

### DIFF
--- a/chart/validator-plugin-azure/crds/validation.spectrocloud.labs_azurevalidators.yaml
+++ b/chart/validator-plugin-azure/crds/validation.spectrocloud.labs_azurevalidators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: azurevalidators.validation.spectrocloud.labs
 spec:
   group: validation.spectrocloud.labs

--- a/config/crd/bases/validation.spectrocloud.labs_azurevalidators.yaml
+++ b/config/crd/bases/validation.spectrocloud.labs_azurevalidators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: azurevalidators.validation.spectrocloud.labs
 spec:
   group: validation.spectrocloud.labs

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
-	github.com/validator-labs/validator v0.1.10
+	github.com/validator-labs/validator v0.1.12
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	k8s.io/api v0.31.1
 	k8s.io/apimachinery v0.31.1

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/validator-labs/validator v0.1.10 h1:0jj6urk4Vp6rNOh3i11qOjoglLmkUvAH3aqDtJ4aFKI=
-github.com/validator-labs/validator v0.1.10/go.mod h1:HHozEO20mmN+TtU5zOD9Rw8tVU9pSHXkJrJAs+WH/XQ=
+github.com/validator-labs/validator v0.1.12 h1:gUEjEi8OvZkI3/4lx5GgbzKQaDShuU2TnLkJKbF/BnY=
+github.com/validator-labs/validator v0.1.12/go.mod h1:QS/zRKFKoi99aQST9djdNR+U+UCaEh+1V9Bt62BJIfc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/azure/community_image_test.go
+++ b/pkg/azure/community_image_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/validator-labs/validator-plugin-azure/api/v1alpha1"
 	vapi "github.com/validator-labs/validator/api/v1alpha1"
+	"github.com/validator-labs/validator/pkg/test"
 	vapitypes "github.com/validator-labs/validator/pkg/types"
 	"github.com/validator-labs/validator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -203,6 +204,6 @@ func TestCommunityGalleryImageRuleService_ReconcileCommunityGalleryImageRule(t *
 	for _, tc := range testCases {
 		svc := NewCommunityGalleryImageRuleService(tc.apiMock, logr.Logger{})
 		result, err := svc.ReconcileCommunityGalleryImageRule(tc.rule)
-		util.CheckTestCase(t, result, tc.expectedResult, err, tc.expectedError)
+		test.CheckTestCase(t, result, tc.expectedResult, err, tc.expectedError)
 	}
 }

--- a/pkg/azure/quota_test.go
+++ b/pkg/azure/quota_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/quota/armquota"
 	"github.com/validator-labs/validator-plugin-azure/api/v1alpha1"
 	vapi "github.com/validator-labs/validator/api/v1alpha1"
+	"github.com/validator-labs/validator/pkg/test"
 	vapitypes "github.com/validator-labs/validator/pkg/types"
 	"github.com/validator-labs/validator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -371,6 +372,6 @@ func TestQuotaRuleService_ReconcileQuotaRule(t *testing.T) {
 	for _, tc := range testCases {
 		svc := NewQuotaRuleService(tc.apiMock)
 		result, err := svc.ReconcileQuotaRule(tc.rule)
-		util.CheckTestCase(t, result, tc.expectedResult, err, tc.expectedError)
+		test.CheckTestCase(t, result, tc.expectedResult, err, tc.expectedError)
 	}
 }

--- a/pkg/azure/rbac_test.go
+++ b/pkg/azure/rbac_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/validator-labs/validator-plugin-azure/api/v1alpha1"
 	vapi "github.com/validator-labs/validator/api/v1alpha1"
+	"github.com/validator-labs/validator/pkg/test"
 	vapitypes "github.com/validator-labs/validator/pkg/types"
 	"github.com/validator-labs/validator/pkg/util"
 )
@@ -263,7 +264,7 @@ func TestRBACRuleService_ReconcileRBACRule(t *testing.T) {
 	for _, tc := range testCases {
 		svc := NewRBACRuleService(tc.daAPIMock, tc.raAPIMock, tc.rdAPIMock)
 		result, err := svc.ReconcileRBACRule(tc.rule)
-		util.CheckTestCase(t, result, tc.expectedResult, err, tc.expectedError)
+		test.CheckTestCase(t, result, tc.expectedResult, err, tc.expectedError)
 	}
 }
 


### PR DESCRIPTION
Bumps dependency and updates code to account for breaking changes.