### PR TITLE
fix: make inline auth work in direct mode too

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.27.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
-	google.golang.org/protobuf v1.35.1 // indirect
+	google.golang.org/protobuf v1.35.2 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.35.1
+	github.com/stretchr/testify v1.9.0
 	github.com/validator-labs/validator v0.1.12
 	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f
 	k8s.io/api v0.31.3
@@ -56,6 +57,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
@@ -74,6 +76,7 @@ require (
 	golang.org/x/tools v0.27.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/controller/azurevalidator_controller.go
+++ b/internal/controller/azurevalidator_controller.go
@@ -38,10 +38,10 @@ import (
 )
 
 const (
-	secretKeyTenantID     = "AZURE_TENANT_ID"
-	secretKeyClientID     = "AZURE_CLIENT_ID"
-	secretKeyClientSecret = "AZURE_CLIENT_SECRET"
-	secretKeyEnvironment  = "AZURE_ENVIRONMENT"
+	scrtKeyTenantID     = "AZURE_TENANT_ID"
+	scrtKeyClientID     = "AZURE_CLIENT_ID"
+	scrtKeyClientSecret = "AZURE_CLIENT_SECRET"
+	scrtKeyEnvironment  = "AZURE_ENVIRONMENT"
 )
 
 // AzureValidatorReconciler reconciles an AzureValidator object
@@ -139,25 +139,25 @@ func (r *AzureValidatorReconciler) authFromSecret(auth v1alpha1.AzureAuth, reqNa
 		return auth, fmt.Errorf("failed to get Secret: %w", err)
 	}
 
-	tenantID, ok := secret.Data[secretKeyTenantID]
+	tenantID, ok := secret.Data[scrtKeyTenantID]
 	if !ok {
-		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", secretKeyTenantID)
+		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", scrtKeyTenantID)
 	}
 	auth.Credentials.TenantID = string(tenantID)
 
-	clientID, ok := secret.Data[secretKeyClientID]
+	clientID, ok := secret.Data[scrtKeyClientID]
 	if !ok {
-		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", secretKeyClientID)
+		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", scrtKeyClientID)
 	}
 	auth.Credentials.ClientID = string(clientID)
 
-	clientSecret, ok := secret.Data[secretKeyClientSecret]
+	clientSecret, ok := secret.Data[scrtKeyClientSecret]
 	if !ok {
-		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", secretKeyClientSecret)
+		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", scrtKeyClientSecret)
 	}
 	auth.Credentials.ClientSecret = string(clientSecret)
 
-	if environment, ok := secret.Data[secretKeyEnvironment]; !ok {
+	if environment, ok := secret.Data[scrtKeyEnvironment]; !ok {
 		l.Info("Azure environment not specified in secret. Using default environment.")
 	} else {
 		auth.Credentials.Environment = string(environment)

--- a/internal/controller/azurevalidator_controller.go
+++ b/internal/controller/azurevalidator_controller.go
@@ -19,9 +19,7 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -34,15 +32,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/validator-labs/validator-plugin-azure/api/v1alpha1"
-	"github.com/validator-labs/validator-plugin-azure/pkg/utils/strings"
 	"github.com/validator-labs/validator-plugin-azure/pkg/validate"
 	vapi "github.com/validator-labs/validator/api/v1alpha1"
 	vres "github.com/validator-labs/validator/pkg/validationresult"
 )
 
-var errInvalidTenantID = errors.New("tenant ID is invalid, must be a v4 uuid")
-var errInvalidClientID = errors.New("client ID is invalid, must be a v4 uuid")
-var errInvalidClientSecret = errors.New("client secret is invalid, must be a non-empty string")
+const (
+	secretKeyTenantID     = "AZURE_TENANT_ID"
+	secretKeyClientID     = "AZURE_CLIENT_ID"
+	secretKeyClientSecret = "AZURE_CLIENT_SECRET"
+	secretKeyEnvironment  = "AZURE_ENVIRONMENT"
+)
 
 // AzureValidatorReconciler reconciles an AzureValidator object
 type AzureValidatorReconciler struct {
@@ -57,6 +57,7 @@ type AzureValidatorReconciler struct {
 
 // Reconcile reconciles each rule found in each AzureValidator in the cluster and creates ValidationResults accordingly
 func (r *AzureValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var err error
 	l := r.Log.V(0).WithValues("name", req.Name, "namespace", req.Namespace)
 	l.Info("Reconciling AzureValidator")
 
@@ -68,9 +69,9 @@ func (r *AzureValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Ensure all four Azure env vars are set.
-	if err := r.configureAzureAuth(validator.Spec.Auth, req.Namespace, l); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to set Azure auth env vars: %w", err)
+	// Override auth data in spec with auth data from Secret if applicable.
+	if validator.Spec.Auth, err = r.authFromSecret(validator.Spec.Auth, req.Namespace, l); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get auth data from Secret: %w", err)
 	}
 
 	// Get the active validator's validation result
@@ -111,87 +112,58 @@ func (r *AzureValidatorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return ctrl.Result{RequeueAfter: time.Second * 120}, nil
 }
 
-// configureAzureAuth sets environment variables used to control which Azure cloud environment is
-// used and which credentials to use for authenticating with Azure. Order or precedence for source:
-// 1 - Kubernetes Secret
-// 2 - Specified inline in spec
-// Validates each value, regardless of its source, and returns an error if env vars couldn't be
-// set for any reason.
-func (r *AzureValidatorReconciler) configureAzureAuth(auth v1alpha1.AzureAuth, reqNamespace string, l logr.Logger) error {
+// Checks whether the spec indicates that auth data should come from a k8s Secret instead of inline
+// auth. If so, all data must come from the Secret. If any is missing, returns an error. If all data
+// is present, overrides the data in the auth object.
+func (r *AzureValidatorReconciler) authFromSecret(auth v1alpha1.AzureAuth, reqNamespace string, l logr.Logger) (v1alpha1.AzureAuth, error) {
+	// If using implicit auth, there is no need to check for k8s Secrets.
 	if auth.Implicit {
 		l.Info("auth.implicit set to true. Skipping setting AZURE_ env vars.")
-		return nil
+		return auth, nil
+	}
+
+	// Same if no secret name provided.
+	if auth.SecretName == "" {
+		l.Info("No Secret name provided. Skipping looking for Secret to override auth data.")
+		return auth, nil
 	}
 
 	if auth.Credentials == nil {
 		auth.Credentials = &v1alpha1.ServicePrincipalCredentials{}
 	}
 
-	// If Secret name provided, override any AZURE_ values with values from its data.
-	if auth.SecretName != "" {
-		l.Info("auth.secretName provided. Using Secret as source for any AZURE_ env vars defined in its data.", "secretName", auth.SecretName, "secretNamespace", reqNamespace)
-		nn := ktypes.NamespacedName{Name: auth.SecretName, Namespace: reqNamespace}
-		secret := &corev1.Secret{}
-		if err := r.Get(context.Background(), nn, secret); err != nil {
-			return fmt.Errorf("failed to get Secret: %w", err)
-		}
-		if tenantID, ok := secret.Data["AZURE_TENANT_ID"]; ok {
-			l.Info("Using tenant ID from Secret.")
-			auth.Credentials.TenantID = string(tenantID)
-		}
-		if clientID, ok := secret.Data["AZURE_CLIENT_ID"]; ok {
-			l.Info("Using client ID from Secret.")
-			auth.Credentials.ClientID = string(clientID)
-		}
-		if clientSecret, ok := secret.Data["AZURE_CLIENT_SECRET"]; ok {
-			l.Info("Using client secret from Secret.")
-			auth.Credentials.ClientSecret = string(clientSecret)
-		}
-		if environment, ok := secret.Data["AZURE_ENVIRONMENT"]; ok {
-			l.Info("Using Azure environment from Secret.")
-			auth.Credentials.Environment = string(environment)
-		}
+	l.Info("auth.secretName provided. Using Secret as source for any AZURE_ env vars defined in its data.", "secretName", auth.SecretName, "secretNamespace", reqNamespace)
+	nn := ktypes.NamespacedName{Name: auth.SecretName, Namespace: reqNamespace}
+	secret := &corev1.Secret{}
+	if err := r.Get(context.Background(), nn, secret); err != nil {
+		return auth, fmt.Errorf("failed to get Secret: %w", err)
 	}
 
-	// Validate values collected from inline config and/or Secret. We can't rely on CRD validation
-	// for this because some of the values may have come from a Secret, and there is no way for the
-	// Kube API to validate content in its data.
-	//
-	// Note that there is no step to validate environment because an empty string is valid. The
-	// Azure SDKs will handle that by defaulting to the public Azure cloud.
-	if !strings.IsValidUUID(auth.Credentials.TenantID) {
-		return errInvalidTenantID
+	tenantID, ok := secret.Data[secretKeyTenantID]
+	if !ok {
+		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", secretKeyTenantID)
 	}
-	if !strings.IsValidUUID(auth.Credentials.ClientID) {
-		return errInvalidClientID
+	auth.Credentials.TenantID = string(tenantID)
+
+	clientID, ok := secret.Data[secretKeyClientID]
+	if !ok {
+		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", secretKeyClientID)
 	}
-	if auth.Credentials.ClientSecret == "" {
-		return errInvalidClientSecret
+	auth.Credentials.ClientID = string(clientID)
+
+	clientSecret, ok := secret.Data[secretKeyClientSecret]
+	if !ok {
+		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", secretKeyClientSecret)
+	}
+	auth.Credentials.ClientSecret = string(clientSecret)
+
+	if environment, ok := secret.Data[secretKeyEnvironment]; !ok {
+		l.Info("Azure environment not specified in secret. Using default environment.")
+	} else {
+		auth.Credentials.Environment = string(environment)
 	}
 
-	// Log non-secret data for help with debugging. Don't log the client secret.
-	nonSecretData := map[string]string{
-		"tenantId":         auth.Credentials.TenantID,
-		"clientId":         auth.Credentials.ClientID,
-		"azureEnvironment": auth.Credentials.Environment,
-	}
-	l.Info("Determined Azure auth data.", "nonSecretData", nonSecretData)
-
-	// Use collected and validated values to set env vars.
-	data := map[string]string{
-		"AZURE_TENANT_ID":     auth.Credentials.TenantID,
-		"AZURE_CLIENT_ID":     auth.Credentials.ClientID,
-		"AZURE_CLIENT_SECRET": auth.Credentials.ClientSecret,
-		"AZURE_ENVIRONMENT":   auth.Credentials.Environment,
-	}
-	for k, v := range data {
-		if err := os.Setenv(k, v); err != nil {
-			return err
-		}
-		r.Log.Info("Set environment variable", "envVar", k)
-	}
-
-	return nil
+	return auth, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/azurevalidator_controller.go
+++ b/internal/controller/azurevalidator_controller.go
@@ -38,10 +38,10 @@ import (
 )
 
 const (
-	scrtKeyTenantID     = "AZURE_TENANT_ID"
-	scrtKeyClientID     = "AZURE_CLIENT_ID"
-	scrtKeyClientSecret = "AZURE_CLIENT_SECRET"
-	scrtKeyEnvironment  = "AZURE_ENVIRONMENT"
+	secretKeyTenantID     = "AZURE_TENANT_ID"     // #nosec G101
+	secretKeyClientID     = "AZURE_CLIENT_ID"     // #nosec G101
+	secretKeyClientSecret = "AZURE_CLIENT_SECRET" // #nosec G101
+	secretKeyEnvironment  = "AZURE_ENVIRONMENT"   // #nosec G101
 )
 
 // AzureValidatorReconciler reconciles an AzureValidator object
@@ -139,25 +139,25 @@ func (r *AzureValidatorReconciler) authFromSecret(auth v1alpha1.AzureAuth, reqNa
 		return auth, fmt.Errorf("failed to get Secret: %w", err)
 	}
 
-	tenantID, ok := secret.Data[scrtKeyTenantID]
+	tenantID, ok := secret.Data[secretKeyTenantID]
 	if !ok {
-		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", scrtKeyTenantID)
+		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", secretKeyTenantID)
 	}
 	auth.Credentials.TenantID = string(tenantID)
 
-	clientID, ok := secret.Data[scrtKeyClientID]
+	clientID, ok := secret.Data[secretKeyClientID]
 	if !ok {
-		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", scrtKeyClientID)
+		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", secretKeyClientID)
 	}
 	auth.Credentials.ClientID = string(clientID)
 
-	clientSecret, ok := secret.Data[scrtKeyClientSecret]
+	clientSecret, ok := secret.Data[secretKeyClientSecret]
 	if !ok {
-		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", scrtKeyClientSecret)
+		return v1alpha1.AzureAuth{}, fmt.Errorf("Key %s missing from Secret", secretKeyClientSecret)
 	}
 	auth.Credentials.ClientSecret = string(clientSecret)
 
-	if environment, ok := secret.Data[scrtKeyEnvironment]; !ok {
+	if environment, ok := secret.Data[secretKeyEnvironment]; !ok {
 		l.Info("Azure environment not specified in secret. Using default environment.")
 	} else {
 		auth.Credentials.Environment = string(environment)

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -3,6 +3,7 @@ package validate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -16,7 +17,12 @@ import (
 	"github.com/validator-labs/validator-plugin-azure/pkg/azure"
 	"github.com/validator-labs/validator-plugin-azure/pkg/constants"
 	utils "github.com/validator-labs/validator-plugin-azure/pkg/utils/azure"
+	"github.com/validator-labs/validator-plugin-azure/pkg/utils/strings"
 )
+
+var errInvalidTenantID = errors.New("tenant ID is invalid, must be a v4 uuid")
+var errInvalidClientID = errors.New("client ID is invalid, must be a v4 uuid")
+var errInvalidClientSecret = errors.New("client secret is invalid, must be a non-empty string")
 
 // Validate validates the AzureValidatorSpec and returns a ValidationResponse.
 func Validate(ctx context.Context, spec v1alpha1.AzureValidatorSpec, log logr.Logger) types.ValidationResponse {
@@ -89,4 +95,62 @@ func buildValidationResult() *types.ValidationRuleResult {
 	latestCondition.ValidationType = constants.PluginCode
 
 	return &types.ValidationRuleResult{Condition: &latestCondition, State: &state}
+}
+
+// Validates the inline auth. The data here could have not passed through kube-apiserver, so we need
+// to validate here instead of relying on CRD validation.
+func validateAuth(auth v1alpha1.AzureAuth) error {
+	if auth.Credentials == nil {
+		auth.Credentials = &v1alpha1.ServicePrincipalCredentials{}
+	}
+
+	var validationErrors []error
+
+	if !strings.IsValidUUID(auth.Credentials.TenantID) {
+		validationErrors = append(validationErrors, errInvalidTenantID)
+	}
+	if !strings.IsValidUUID(auth.Credentials.ClientID) {
+		validationErrors = append(validationErrors, errInvalidClientID)
+	}
+	if auth.Credentials.ClientSecret == "" {
+		validationErrors = append(validationErrors, errInvalidClientSecret)
+	}
+
+	if len(validationErrors) > 0 {
+		return errors.Join(validationErrors...)
+	}
+	return nil
+}
+
+// Sets environment variables needed by the Azure SDK from the inline auth. The inline auth is
+// assumed to have already been validated.
+func configureAuth(auth v1alpha1.AzureAuth, log logr.Logger) error {
+	if auth.Implicit {
+		log.Info("auth.implicit set to true. Skipping setting AZURE_ env vars.")
+		return nil
+	}
+
+	// Log non-secret data for help with debugging. Don't log the client secret.
+	nonSecretData := map[string]string{
+		"tenantId":    auth.Credentials.TenantID,
+		"clientId":    auth.Credentials.ClientID,
+		"environment": auth.Credentials.Environment,
+	}
+	log.Info("Determined Azure auth data.", "nonSecretData", nonSecretData)
+
+	// Use collected and validated values to set env vars.
+	data := map[string]string{
+		"AZURE_TENANT_ID":     auth.Credentials.TenantID,
+		"AZURE_CLIENT_ID":     auth.Credentials.ClientID,
+		"AZURE_CLIENT_SECRET": auth.Credentials.ClientSecret,
+		"AZURE_ENVIRONMENT":   auth.Credentials.Environment,
+	}
+	for k, v := range data {
+		if err := os.Setenv(k, v); err != nil {
+			return err
+		}
+		log.Info("Set environment variable", "envVar", k)
+	}
+
+	return nil
 }

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -1,0 +1,191 @@
+package validate
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"github.com/validator-labs/validator-plugin-azure/api/v1alpha1"
+	//+kubebuilder:scaffold:imports
+)
+
+func Test_validateAuth(t *testing.T) {
+	tenID := uuid.New().String()
+	cliID := uuid.New().String()
+
+	type args struct {
+		auth v1alpha1.AzureAuth
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "No error for valid inline auth data",
+			args: args{
+				auth: v1alpha1.AzureAuth{
+					Credentials: &v1alpha1.ServicePrincipalCredentials{
+						TenantID:     tenID,
+						ClientID:     cliID,
+						ClientSecret: "c",
+						Environment:  "d",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "No panic for nil auth.Credentials",
+			args: args{
+				auth: v1alpha1.AzureAuth{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error for invalid tenant ID",
+			args: args{
+				auth: v1alpha1.AzureAuth{
+					Credentials: &v1alpha1.ServicePrincipalCredentials{
+						TenantID:     "",
+						ClientID:     cliID,
+						ClientSecret: "c",
+						Environment:  "d",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error for invalid client ID",
+			args: args{
+				auth: v1alpha1.AzureAuth{
+					Credentials: &v1alpha1.ServicePrincipalCredentials{
+						TenantID:     tenID,
+						ClientID:     "",
+						ClientSecret: "c",
+						Environment:  "d",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error for invalid client secret",
+			args: args{
+				auth: v1alpha1.AzureAuth{
+					Credentials: &v1alpha1.ServicePrincipalCredentials{
+						TenantID:     tenID,
+						ClientID:     cliID,
+						ClientSecret: "",
+						Environment:  "d",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "No error for valid auth data but missing environment",
+			args: args{
+				auth: v1alpha1.AzureAuth{
+					Credentials: &v1alpha1.ServicePrincipalCredentials{
+						TenantID:     tenID,
+						ClientID:     cliID,
+						ClientSecret: "c",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateAuth(tt.args.auth); (err != nil) != tt.wantErr {
+				t.Errorf("validateAuth() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_configureAuth(t *testing.T) {
+	tenID := uuid.New().String()
+	cliID := uuid.New().String()
+
+	type args struct {
+		auth v1alpha1.AzureAuth
+		log  logr.Logger
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantErr     bool
+		wantEnvVars map[string]string
+	}{
+		{
+			name: "Sets all env vars given inline auth config",
+			args: args{
+				auth: v1alpha1.AzureAuth{
+					Credentials: &v1alpha1.ServicePrincipalCredentials{
+						TenantID:     tenID,
+						ClientID:     cliID,
+						ClientSecret: "c",
+						Environment:  "d",
+					},
+				},
+			},
+			wantErr: false,
+			wantEnvVars: map[string]string{
+				"AZURE_TENANT_ID":     tenID,
+				"AZURE_CLIENT_ID":     cliID,
+				"AZURE_CLIENT_SECRET": "c",
+				"AZURE_ENVIRONMENT":   "d",
+			},
+		},
+		{
+			name: "No env vars set when implicit auth enabled",
+			args: args{
+				auth: v1alpha1.AzureAuth{
+					Implicit: true,
+				},
+			},
+			wantErr:     false,
+			wantEnvVars: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save the current environment variables to restore them later
+			originalEnv := make(map[string]string)
+			for k := range tt.wantEnvVars {
+				originalEnv[k] = os.Getenv(k)
+			}
+
+			// Clean up and reset environment variables after the test
+			defer func() {
+				for k, v := range originalEnv {
+					if v == "" {
+						os.Unsetenv(k)
+					} else {
+						os.Setenv(k, v)
+					}
+				}
+			}()
+
+			// Check err result
+			if err := configureAuth(tt.args.auth, tt.args.log); (err != nil) != tt.wantErr {
+				t.Errorf("configureAuth() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Check env var result
+			actualEnvVars := make(map[string]string)
+			for k := range tt.wantEnvVars {
+				actualEnvVars[k] = os.Getenv(k)
+			}
+			if !reflect.DeepEqual(actualEnvVars, tt.wantEnvVars) {
+				t.Errorf("Env vars = %v; want %v", actualEnvVars, tt.wantEnvVars)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue
Resolves https://github.com/validator-labs/validator-plugin-azure/issues/300.

## Description
The original implementation of inline auth only worked in continuous mode because the code that sets env vars for the Azure SDK was in `Reconcile` and was therefore not invoked by `Validate` (which direct mode invokes). This fixes it by moving that code to `Validate` so that it will run during direct mode too.

Also changes how the Secret is treated so that if there is any issue using the Secret for auth data based on what the user put in the validator spec, it results in an error that prevents reconciliation from continuing. This matches the behavior of other plugins.
