### PR TITLE
fix: metrics targetPort https -> 8443

### DIFF
--- a/chart/validator-plugin-azure/README.md
+++ b/chart/validator-plugin-azure/README.md
@@ -26,7 +26,7 @@ The following table lists the configurable parameters of the Validator-plugin-az
 | `controllerManager.volumes` |  | `[]` |
 | `controllerManager.podLabels` |  | `{}` |
 | `kubernetesClusterDomain` |  | `"cluster.local"` |
-| `metricsService.ports` |  | `[{"name": "https", "port": 8443, "protocol": "TCP", "targetPort": "https"}]` |
+| `metricsService.ports` |  | `[{"name": "https", "port": 8443, "protocol": "TCP", "targetPort": 8443}]` |
 | `metricsService.type` |  | `"ClusterIP"` |
 | `auth.serviceAccountName` |  | `""` |
 | `azureEnvironment` |  | `"AzureCloud"` |

--- a/chart/validator-plugin-azure/values.yaml
+++ b/chart/validator-plugin-azure/values.yaml
@@ -36,7 +36,7 @@ metricsService:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   type: ClusterIP
 auth:
   # Override the service account used by Azure validator (optional, could be used for WorkloadIdentityCredentials on AKS)


### PR DESCRIPTION
Metrics server is exposed on port 8443. This PR updates the metrics service chart value to match this, to ensure it's accessible.
